### PR TITLE
fixed field hiding in admin for Django 1.4.3

### DIFF
--- a/inline_ordering/static/inline_ordering.js
+++ b/inline_ordering/static/inline_ordering.js
@@ -41,6 +41,7 @@ var InlineOrdering = {
         });
         //jQuery("div.inline-group").disableSelection();
         
+        InlineOrdering.jQuery('div.field-inline_ordering_position').hide();
         InlineOrdering.jQuery('div.inline_ordering_position').hide();
         InlineOrdering.jQuery('td.inline_ordering_position input').hide();
         


### PR DESCRIPTION
I'm running Django 1.4.3, and I noticed that I was seeing the inline ordering field in the admin.  This patch fixed the problem for me.

FWIW, I also had to use a [forked version of django-admin-jqueryui](https://github.com/baldurthoremilsson/django-admin-jqueryui)
